### PR TITLE
correct numbers.validation.yaml

### DIFF
--- a/conf/examples/numbers.validation.yaml
+++ b/conf/examples/numbers.validation.yaml
@@ -79,7 +79,7 @@ paths:
           required: true
           type: number
           format: float
-          maximum: 10
+          maximum: 20
           minimum: 10
           exclusiveMinimum: true
           exclusiveMaximum: true


### PR DESCRIPTION
the configuration for float_required was incorrect, making it impossible to submit a valid value.